### PR TITLE
Improve Ocamlformat_utils and add Migrate_utils

### DIFF
--- a/bin/lwt_ppx_to_let_syntax/ast_transforms.ml
+++ b/bin/lwt_ppx_to_let_syntax/ast_transforms.ml
@@ -353,7 +353,7 @@ let with_scoped_ext ext f =
   | "shared" -> scoped Shared
   | _ -> f ()
 
-let remove_lwt_ppx ~use_lwt_bind:use_lwt_bind_ str =
+let remove_lwt_ppx_str ~use_lwt_bind:use_lwt_bind_ str =
   use_lwt_bind := use_lwt_bind_;
   letop_was_used := None;
   let default = Ast_mapper.default_mapper in
@@ -372,7 +372,16 @@ let remove_lwt_ppx ~use_lwt_bind:use_lwt_bind_ str =
   in
   let m = { default with expr; extension; value_binding } in
   let str = m.structure m str in
-  match !letop_was_used with
-  | Some scope when not (structure_has_open_lwt_syntax str) ->
-      mk_open_lwt_syntax scope :: str
-  | _ -> str
+  let str =
+    match !letop_was_used with
+    | Some scope when not (structure_has_open_lwt_syntax str) ->
+        mk_open_lwt_syntax scope :: str
+    | _ -> str
+  in
+  (str, [])
+
+let remove_lwt_ppx ~use_lwt_bind =
+  {
+    Ocamlformat_utils.structure = remove_lwt_ppx_str ~use_lwt_bind;
+    signature = (fun x -> (x, []));
+  }

--- a/bin/lwt_ppx_to_let_syntax/ast_transforms.mli
+++ b/bin/lwt_ppx_to_let_syntax/ast_transforms.mli
@@ -1,4 +1,2 @@
-open Ocamlformat_parser_extended.Parsetree
-
-val remove_lwt_ppx : use_lwt_bind:bool -> structure -> structure
+val remove_lwt_ppx : use_lwt_bind:bool -> Ocamlformat_utils.modify_ast
 (** Rewrite occurrences of lwt ppx to Lwt library function calls. *)

--- a/bin/lwt_ppx_to_let_syntax/main.ml
+++ b/bin/lwt_ppx_to_let_syntax/main.ml
@@ -1,5 +1,5 @@
 let migrate_file ~formatted ~errors ~modify_ast file =
-  match Ocamlformat_utils.format_structure_in_place ~file ~modify_ast with
+  match Ocamlformat_utils.format_in_place ~file ~modify_ast with
   | Ok () -> incr formatted
   | Error (`Msg msg) ->
       Format.eprintf "%s: %s\n%!" file msg;

--- a/lib/fs_utils/fs_utils.ml
+++ b/lib/fs_utils/fs_utils.ml
@@ -1,3 +1,15 @@
+(** List files in a directory. Returns an empty array on error. *)
+let list_dir p =
+  match Sys.readdir p with
+  | exception Sys_error msg ->
+      Printf.eprintf "%s\n%!" msg;
+      [||]
+  | files ->
+      (* Sorted to ensure reproducibility. *)
+      Array.sort String.compare files;
+      Array.iteri (fun i fname -> files.(i) <- Filename.concat p fname) files;
+      files
+
 let rec scan_dir ~descend_into f acc path =
   match Sys.is_directory path with
   | exception Sys_error msg ->
@@ -8,16 +20,7 @@ let rec scan_dir ~descend_into f acc path =
   | false -> f acc path
 
 and _scan_dir ~descend_into f acc parent =
-  match Sys.readdir parent with
-  | exception Sys_error msg ->
-      Printf.eprintf "%s\n%!" msg;
-      acc
-  | files ->
-      Array.sort String.compare files;
-      Array.fold_left
-        (fun acc child ->
-          scan_dir ~descend_into f acc (Filename.concat parent child))
-        acc files
+  Array.fold_left (scan_dir ~descend_into f) acc (list_dir parent)
 
 (** Call [f] on every files found recursively into [path]. [descend_into] is
     called on every directories. Directories for which [descend_into] is [false]
@@ -29,7 +32,7 @@ let scan_dir ?(descend_into = fun _ -> true) f acc path =
 let find_ml_files f path =
   let is_ml_file fname =
     match Filename.extension fname with
-    | ".ml" | ".eliom" -> true
+    | ".ml" | ".eliom" | ".mli" | ".eliomi" -> true
     | ext ->
         (* Accept extensions of the form [foo.client.ml] *)
         String.ends_with ~suffix:".ml" ext

--- a/lib/migrate_utils/dune
+++ b/lib/migrate_utils/dune
@@ -1,0 +1,8 @@
+(library
+ (name migrate_utils)
+ (libraries
+  compiler-libs
+  merlin-lib.index_format
+  merlin-lib.ocaml_typing
+  fs_utils
+  ocamlformat_utils))

--- a/lib/migrate_utils/migrate_utils.ml
+++ b/lib/migrate_utils/migrate_utils.ml
@@ -1,6 +1,106 @@
 open Ocamlformat_utils.Parsing
+open Parsetree
 
-type occurrences = ((string * string) * Longident.t Location.loc) list
+module Loc = struct
+  type t = {
+    line : int;
+    col : int;
+    len : int; [@warning "-69"]
+        (* Silent unused-field warning. This field is used implicitly by
+         polymorphic compare in [Hashtbl]. *)
+  }
+  (** Remove information from the [Location.t] to avoid problems with different
+      filenames due to custom Dune rules and offset positions due to PPXes. *)
+
+  let of_location { Location.loc_start; loc_end; _ } =
+    {
+      line = loc_start.pos_lnum;
+      col = loc_start.pos_cnum - loc_start.pos_bol;
+      len = loc_end.pos_cnum - loc_start.pos_cnum;
+    }
+
+  let pp ppf loc = Format.fprintf ppf "line %d column %d" loc.line (loc.col + 1)
+end
+
+type state = {
+  occ : (Loc.t, string * string) Hashtbl.t;
+  mutable comments : Ocamlformat_utils.Cmt.t list;
+  mutable comment_default_loc : Location.t;
+}
+
+let add_comment state ?(loc = state.comment_default_loc) text =
+  let cmt = " " ^ text ^ " " in
+  state.comments <-
+    Ocamlformat_utils.Cmt.create_comment cmt loc :: state.comments
+
+let set_default_comment_loc state loc = state.comment_default_loc <- loc
+
+module Occ = struct
+  open Location
+
+  let init lids =
+    let new_tbl = Hashtbl.create (List.length lids) in
+    List.iter
+      (fun (ident, lid) ->
+        Hashtbl.replace new_tbl (Loc.of_location lid.loc) ident)
+      lids;
+    new_tbl
+
+  let remove state lid = Hashtbl.remove state.occ (Loc.of_location lid.loc)
+
+  let pop state lid =
+    if Hashtbl.mem state.occ (Loc.of_location lid.loc) then (
+      remove state lid;
+      true)
+    else false
+
+  let may_rewrite state lid f =
+    match Hashtbl.find_opt state.occ (Loc.of_location lid.loc) with
+    | Some ident ->
+        let r = f ident in
+        if Option.is_some r then remove state lid;
+        r
+    | None -> None
+
+  (** Warn about locations that have not been rewritten so far. *)
+  let warn_missing_locs state fname =
+    let missing = Hashtbl.length state.occ in
+    if missing > 0 then (
+      Format.eprintf "Warning: %s: %d occurrences have not been rewritten.@\n"
+        fname missing;
+      Hashtbl.fold
+        (fun loc (unit_name, ident) acc ->
+          (loc, unit_name ^ "." ^ ident) :: acc)
+        state.occ []
+      |> List.sort compare (* Sort for a reproducible output. *)
+      |> List.iter (fun (loc, ident) ->
+             Format.eprintf "  %s (%a)@\n" ident Loc.pp loc);
+      Format.eprintf "%!")
+end
+
+type modify_ast = {
+  structure : state -> structure -> structure;
+  signature : state -> signature -> signature;
+}
+
+let make_modify_ast ~modify_ast ~fname occurrences =
+  let modify_ast = modify_ast ~fname in
+  let rewrite f x =
+    let state =
+      {
+        occ = Occ.init occurrences;
+        comments = [];
+        comment_default_loc = Location.none;
+      }
+    in
+    let r = f state x in
+    Occ.warn_missing_locs state fname;
+    (r, state.comments)
+  in
+  {
+    Ocamlformat_utils.structure = rewrite modify_ast.structure;
+    signature = rewrite modify_ast.signature;
+  }
 
 let errorf fmt = Format.kasprintf (fun msg -> Error (`Msg msg)) fmt
 
@@ -55,7 +155,7 @@ let migrate ~packages ~units ~modify_ast =
   let formatted = ref 0 in
   let filename_map = lookup_filename_map () in
   group_occurrences_by_file occurs (fun fname occurrences ->
-      let modify_ast = modify_ast ~fname occurrences in
+      let modify_ast = make_modify_ast ~modify_ast ~fname occurrences in
       migrate_file ~filename_map ~formatted ~errors ~modify_ast fname);
   Format.printf "Formatted %d files, %d errors\n%!" !formatted !errors;
   if !errors > 0 then exit 1

--- a/lib/migrate_utils/migrate_utils.ml
+++ b/lib/migrate_utils/migrate_utils.ml
@@ -1,0 +1,73 @@
+open Ocamlformat_utils.Parsing
+
+type occurrences = ((string * string) * Longident.t Location.loc) list
+
+let errorf fmt = Format.kasprintf (fun msg -> Error (`Msg msg)) fmt
+
+(** Map from file names to their path. This is used when locations point to the
+    wrong path (eg. it only contains the basename), which is often the case with
+    [.eliom] files. *)
+let lookup_filename_map () =
+  let tbl = Hashtbl.create 64 in
+  Fs_utils.find_ml_files
+    (fun path -> Hashtbl.add tbl (Filename.basename path) path)
+    ".";
+  tbl
+
+let resolve_file_name ~filename_map path =
+  if Sys.file_exists path then Ok path
+  else
+    match Hashtbl.find_all filename_map (Filename.basename path) with
+    | [] -> errorf "Couldn't find file %S" path
+    | _ :: _ :: _ -> errorf "Ambiguous location in index for file %S" path
+    | [ f ] -> Ok f
+
+(** Call [f] for every files that contain occurrences of [Lwt]. *)
+let group_occurrences_by_file lids f =
+  let module Tbl = Hashtbl.Make (String) in
+  let tbl = Tbl.create 64 in
+  List.iter
+    (fun ((_ident, lid) as occ) ->
+      let file = lid.Location.loc.loc_start.pos_fname in
+      Tbl.replace tbl file
+        (match Tbl.find_opt tbl file with
+        | Some lids -> occ :: lids
+        | None -> [ occ ]))
+    lids;
+  Tbl.iter f tbl
+
+let migrate_file ~filename_map ~formatted ~errors ~modify_ast file =
+  let ( >>= ) = Result.bind in
+  match
+    resolve_file_name ~filename_map file >>= fun file ->
+    Ocamlformat_utils.format_in_place ~file ~modify_ast
+  with
+  | Ok () -> incr formatted
+  | Error (`Msg msg) ->
+      Format.eprintf "%s: %s\n%!" file msg;
+      incr errors
+
+let dune_build_dir = "_build"
+
+let migrate ~packages ~units ~modify_ast =
+  let occurs = Ocaml_index_utils.occurrences ~dune_build_dir ~packages ~units in
+  let errors = ref 0 in
+  let formatted = ref 0 in
+  let filename_map = lookup_filename_map () in
+  group_occurrences_by_file occurs (fun fname occurrences ->
+      let modify_ast = modify_ast ~fname occurrences in
+      migrate_file ~filename_map ~formatted ~errors ~modify_ast fname);
+  Format.printf "Formatted %d files, %d errors\n%!" !formatted !errors;
+  if !errors > 0 then exit 1
+
+let print_occurrences ~packages ~units =
+  let occurs = Ocaml_index_utils.occurrences ~dune_build_dir ~packages ~units in
+  let pp_occurrence ppf ((unit_name, ident), lid) =
+    Format.fprintf ppf "%s.%s %a" unit_name ident Printast.fmt_location
+      lid.Location.loc
+  in
+  group_occurrences_by_file occurs (fun file occurrences ->
+      Format.printf "@[<v 2>%s: (%d occurrences)@ %a@]@\n" file
+        (List.length occurrences)
+        (Format.pp_print_list pp_occurrence)
+        occurrences)

--- a/lib/migrate_utils/migrate_utils.mli
+++ b/lib/migrate_utils/migrate_utils.mli
@@ -1,0 +1,15 @@
+open Ocamlformat_utils.Parsing
+
+type occurrences = ((string * string) * Longident.t Location.loc) list
+
+val migrate :
+  packages:string list ->
+  units:(string -> bool) ->
+  modify_ast:(fname:string -> occurrences -> Ocamlformat_utils.modify_ast) ->
+  unit
+(** Modify files containing occurrences to modules matched by [units] of
+    packages [packages] using [modify_ast]. Will scan file in [_build] and in
+    the current directory. *)
+
+val print_occurrences : packages:string list -> units:(string -> bool) -> unit
+(** Print occurrences that would be rewritten by [migrate]. *)

--- a/lib/migrate_utils/migrate_utils.mli
+++ b/lib/migrate_utils/migrate_utils.mli
@@ -1,11 +1,44 @@
 open Ocamlformat_utils.Parsing
+open Parsetree
 
-type occurrences = ((string * string) * Longident.t Location.loc) list
+type state
+
+module Occ : sig
+  (** Manage occurrences of identifiers that should be migrated. *)
+
+  val pop : state -> 'a Location.loc -> bool
+  (** Whether the given longident is an occurrence of an Lwt function. This will
+      change the internal table and any subsequent calls for the same longident
+      will return [false]. *)
+
+  val may_rewrite :
+    state -> 'a Location.loc -> (string * string -> 'b option) -> 'b option
+  (** Calls [f] if [lid] should be rewritten. A rewrite happen if
+      [f (unit_name, ident)] is [Some ast] where [ident] is the basename of the
+      longident at [lid]. The occurrence is removed from the table if a rewrite
+      happened. *)
+
+  val remove : state -> 'a Location.loc -> unit
+  (** Remove an occurrence from the table. *)
+end
+
+val add_comment : state -> ?loc:Location.t -> string -> unit
+(** Add comments in the output. Comments are attached to a location that must
+    appear in the output AST and cannot be a ghost location. If [loc] is [None],
+    use the location set with [set_default_comment_loc] instead. *)
+
+val set_default_comment_loc : state -> Location.t -> unit
+(** Set the default location for comments added with [add_comment]. *)
+
+type modify_ast = {
+  structure : state -> structure -> structure;
+  signature : state -> signature -> signature;
+}
 
 val migrate :
   packages:string list ->
   units:(string -> bool) ->
-  modify_ast:(fname:string -> occurrences -> Ocamlformat_utils.modify_ast) ->
+  modify_ast:(fname:string -> modify_ast) ->
   unit
 (** Modify files containing occurrences to modules matched by [units] of
     packages [packages] using [modify_ast]. Will scan file in [_build] and in

--- a/lib/migrate_utils/ocaml_index_utils.ml
+++ b/lib/migrate_utils/ocaml_index_utils.ml
@@ -1,0 +1,125 @@
+let fail fmt = Printf.ksprintf failwith fmt
+
+(** Convert from OCaml [Parsing] values that Merlin uses to the corresponding
+    Ocamlformat type. *)
+module Ocaml_to_ocamlformat = struct
+  open Ocamlformat_utils.Parsing
+
+  let location_t { Ocaml_parsing.Location.loc_start; loc_end; loc_ghost } =
+    { Location.loc_start; loc_end; loc_ghost }
+
+  let location_loc f { Ocaml_parsing.Location.txt; loc } =
+    { Location.txt = f txt; loc = location_t loc }
+
+  let rec longident =
+    let open Longident in
+    function
+    | Ocaml_parsing.Longident.Lident s -> Lident s
+    | Ldot (a, b) -> Ldot (longident a, b)
+    | Lapply (a, b) -> Lapply (longident a, longident b)
+
+  let lid = location_loc longident
+end
+
+(* Find all the [.ocaml-index] files. *)
+let scan_dune_build_path ~dune_build_dir =
+  if not (Sys.is_directory dune_build_dir) then
+    fail "Directory %S not found." dune_build_dir
+  else
+    let collect_index_files acc path =
+      if Filename.extension path = ".ocaml-index" then path :: acc else acc
+    in
+    match Fs_utils.scan_dir collect_index_files [] dune_build_dir with
+    | [] -> failwith "No index found. Please run 'dune build @ocaml-index'."
+    | p -> p
+
+(* Query a package's lib path using [ocamlfind]. *)
+let package_lib_paths packages =
+  let cmd = Filename.quote_command "ocamlfind" ("query" :: packages) in
+  let ic = Unix.open_process_in cmd in
+  let lib_paths = String.trim (In_channel.input_all ic) in
+  match Unix.close_process_in ic with
+  | WEXITED 0 -> String.split_on_char '\n' lib_paths
+  | _ -> fail "Command %S failed." cmd
+
+(* Lookup the uid_map for a unit. *)
+let uid_map_of_unit ~packages ~units =
+  let open Ocaml_typing in
+  let cmts =
+    let acc_matching_cmts acc fname =
+      let basename = Filename.basename fname in
+      let unit_name =
+        String.capitalize_ascii (Filename.remove_extension basename)
+      in
+      if Filename.extension basename = ".cmt" && units unit_name then
+        (unit_name, fname) :: acc
+      else acc
+    in
+    (* Lookup [.cmt] files matched by [units]. *)
+    package_lib_paths packages
+    |> List.fold_left
+         (fun acc lib_path ->
+           Fs_utils.list_dir lib_path |> Array.fold_left acc_matching_cmts acc)
+         []
+  in
+  let ident_of_decl ~unit_name = function
+    | Typedtree.Value { val_id = ident; _ }
+    | Type { typ_id = ident; _ }
+    | Value_binding { vb_pat = { pat_desc = Tpat_var (ident, _, _); _ }; _ }
+    | Constructor { cd_id = ident; _ }
+    | Extension_constructor { ext_id = ident; _ } ->
+        `Found (unit_name, Ident.name ident)
+    | _ -> `Ignore
+  in
+  let module Tbl = Shape.Uid.Tbl in
+  let tbl = Tbl.create 256 in
+  List.iter
+    (fun (unit_name, cmt) ->
+      let cmt = Cmt_format.read_cmt cmt in
+      Tbl.iter
+        (fun uid decl -> Tbl.replace tbl uid (ident_of_decl ~unit_name decl))
+        cmt.cmt_uid_to_decl)
+    cmts;
+  fun uid ->
+    match Tbl.find_opt tbl uid with
+    | Some ((`Found _ | `Ignore) as r) -> r
+    | None -> `Not_found
+
+let pp_ocaml_lid ppf { Ocaml_parsing.Location.txt; loc } =
+  let open Ocaml_parsing in
+  Format.fprintf ppf "@[<hv 2>%a:@ %a@]" Pprintast.longident txt
+    Location.print_loc loc
+
+(* Read the index files and extract all occurrences of [units]. *)
+let extract_occurrences_of_unit ~units ~lookup_ident paths =
+  let open Merlin_index_format.Index_format in
+  List.fold_left
+    (fun acc file ->
+      match read ~file with
+      | Index index ->
+          Uid_map.fold
+            (fun uid locs acc ->
+              match lookup_ident uid with
+              | `Found ident ->
+                  Lid_set.fold
+                    (fun loc acc ->
+                      (ident, Ocaml_to_ocamlformat.lid loc) :: acc)
+                    locs acc
+              | `Ignore -> (* Not a value *) acc
+              | `Not_found -> (
+                  match uid with
+                  | Item { comp_unit; id } when units comp_unit ->
+                      Format.eprintf "@[<v 2>No ident for uid %s.%d:@ %a@]@\n%!"
+                        comp_unit id
+                        (Format.pp_print_list pp_ocaml_lid)
+                        (Lid_set.elements locs);
+                      acc
+                  | _ -> acc))
+            index.defs acc
+      | _ -> acc)
+    [] paths
+
+let occurrences ~dune_build_dir ~packages ~units =
+  let paths = scan_dune_build_path ~dune_build_dir in
+  let lookup_ident = uid_map_of_unit ~packages ~units in
+  extract_occurrences_of_unit ~units ~lookup_ident paths

--- a/lib/migrate_utils/ocaml_index_utils.mli
+++ b/lib/migrate_utils/ocaml_index_utils.mli
@@ -1,0 +1,10 @@
+open Ocamlformat_utils.Parsing
+
+val occurrences :
+  dune_build_dir:string ->
+  packages:string list ->
+  units:(string -> bool) ->
+  ((string * string) * Longident.t Location.loc) list
+(** Find all the occurrences of values from module matched by [units] of
+    packages matching the ocamlfind query specified with [package_query] in the
+    [.ocaml-index] files found in Dune's [_build] directory. *)

--- a/lib/ocamlformat_utils/ast_utils.ml
+++ b/lib/ocamlformat_utils/ast_utils.ml
@@ -13,25 +13,40 @@ let mk_let' ?(loc_in = !default_loc) ?(rec_ = Nonrecursive) bindings rhs =
   let bindings = { pvbs_bindings = bindings; pvbs_rec = rec_ } in
   Exp.let_ ~loc_in bindings rhs
 
-let mk_let ?loc_in ?rec_ pat ?(args = []) lhs rhs =
-  let binding = Vb.mk ~is_pun:false pat args (Pfunction_body lhs) in
+let mk_let ?loc_in ?rec_ ?(is_pun = false) ?value_constraint pat ?(args = [])
+    lhs rhs =
+  let binding = Vb.mk ~is_pun ?value_constraint pat args (Pfunction_body lhs) in
   mk_let' ?loc_in ?rec_ [ binding ] rhs
 
 let mk_function_cases ?(loc = !default_loc) ?(attrs = []) cases =
   Exp.function_ [] None (Pfunction_cases (cases, loc, attrs))
 
-let mk_longident = function
+let mk_longident' = function
   | [] -> assert false
   | hd :: tl ->
       let open Longident in
-      mk_loc (List.fold_left (fun acc seg -> Ldot (acc, seg)) (Lident hd) tl)
+      List.fold_left (fun acc seg -> Ldot (acc, seg)) (Lident hd) tl
 
-let mk_exp_var s = Exp.ident (mk_longident [ s ])
+let mk_longident ident = mk_loc (mk_longident' ident)
+let mk_constr_exp ?arg cstr = Exp.construct (mk_longident [ cstr ]) arg
+let same_longident a b = Longident.flatten a = b
+let mk_exp_ident ident = Exp.ident (mk_longident ident)
+let mk_exp_var s = mk_exp_ident [ s ]
 let mk_unit_ident = mk_longident [ "()" ]
 let mk_unit_pat = Pat.construct mk_unit_ident None
 let mk_unit_arg = mk_function_param mk_unit_pat
 let mk_unit_val = Exp.construct mk_unit_ident None
 let mk_thunk body = Exp.function_ [ mk_unit_arg ] None (Pfunction_body body)
+let mk_some_ident = mk_longident [ "Some" ]
+let mk_none_ident = mk_longident [ "None" ]
+let mk_exp_some x = Exp.construct mk_some_ident (Some x)
+let mk_exp_none = Exp.construct mk_none_ident None
+let mk_typ_constr ?(params = []) lid = Typ.constr (mk_longident lid) params
+
+let is_unit_val = function
+  | { pexp_desc = Pexp_construct (ident, None); _ } ->
+      same_longident ident.txt [ "()" ]
+  | _ -> false
 
 let mk_if if_cond if_body else_body =
   let mk_if_cond ?(loc_then = !default_loc) ?(attrs = []) if_cond if_body =
@@ -42,3 +57,9 @@ let mk_if if_cond if_body else_body =
 let mk_binding_op ?(loc = !default_loc) ?(is_pun = false) op pat ?(args = [])
     ?(typ = None) exp =
   Exp.binding_op op pat args typ exp is_pun loc
+
+let mk_lbl s = Labelled (mk_loc s)
+let mk_apply_ident ident args = Exp.apply (mk_exp_ident ident) args
+
+let mk_apply_simple f_ident args =
+  mk_apply_ident f_ident (List.map (fun x -> (Nolabel, x)) args)

--- a/lib/ocamlformat_utils/ast_utils.ml
+++ b/lib/ocamlformat_utils/ast_utils.ml
@@ -63,3 +63,118 @@ let mk_apply_ident ident args = Exp.apply (mk_exp_ident ident) args
 
 let mk_apply_simple f_ident args =
   mk_apply_ident f_ident (List.map (fun x -> (Nolabel, x)) args)
+
+(** Flatten a pipelines composed of [|>] and [@@] into a [Pexp_apply] node. *)
+let rec flatten_apply exp =
+  let flatten callee arg =
+    let callee, prefix_args =
+      match (flatten_apply callee).pexp_desc with
+      | Pexp_apply (callee, prefix_args) -> (callee, prefix_args)
+      | _ -> (callee, [])
+    in
+    Exp.apply callee (prefix_args @ [ (Nolabel, arg) ])
+  in
+  match exp.pexp_desc with
+  | Pexp_infix ({ txt = "@@"; _ }, lhs, rhs) -> flatten lhs rhs
+  | Pexp_infix ({ txt = "|>"; _ }, lhs, rhs) -> flatten rhs lhs
+  | _ -> exp
+
+module Unpack_apply : sig
+  type t
+
+  val unapply : (arg_label * expression) list -> t -> expression option
+  (** Decode a list of arguments matching a sequence of [take] instructions
+      ending in a [return]. If the argument list is smaller than expected, a
+      function node is generated to respect the arity and allow the expression
+      to be rewritten. Return [None] if the argument list couldn't be unapplied.
+  *)
+
+  val take : (expression -> t) -> t
+  (** Accept one argument. *)
+
+  val take_lbl : string -> (expression -> t) -> t
+  (** Accept a labelled argument. It's safer to accept all the labelled
+      arguments first before accepting any unlabelled argument. *)
+
+  val take_lblopt : string -> ((expression * [ `Opt | `Lbl ]) option -> t) -> t
+  (** Accept an optional labelled argument. [`Opt] indicates that the passed
+      value is an option passed using [?lbl:...] and [`Lbl] indicates that the
+      value is passed as [~lbl:...]. See [take_lbl]. *)
+
+  val take_all : ((arg_label * expression) list -> expression option) -> t
+  (** Accept all remaining arguments. *)
+
+  val return : expression option -> t
+  (** Stop accepting arguments. [return (Some exp)] rewrites the apply
+      expression to [exp] while [return None] leaves the original expression.
+      The "too many arguments" warning is not triggered with [return None]. *)
+end = struct
+  type t =
+    | Arg of (expression -> t)
+    | Label of string * (expression -> t)
+    | Label_opt of string * ((expression * [ `Opt | `Lbl ]) option -> t)
+    | Take_all of ((arg_label * expression) list -> expression option)
+    | End of expression option
+
+  let rec apply_remaining_args params i = function
+    | Arg k -> apply_remaining_next params i Nolabel k
+    | Label (lbl, k) -> apply_remaining_next params i (Labelled (mk_loc lbl)) k
+    | Label_opt (lbl, k) ->
+        apply_remaining_next params i
+          (Optional (mk_loc lbl))
+          (fun arg -> k (Some (arg, `Opt)))
+    | End r -> apply_remaining_end params r
+    | Take_all k -> apply_remaining_end params (k [])
+
+  and apply_remaining_next params i lbl k =
+    let ident = "x" ^ string_of_int i in
+    let new_param = mk_function_param ~lbl (Pat.var (mk_loc ident)) in
+    let expr = mk_exp_ident [ ident ] in
+    apply_remaining_args (new_param :: params) (i + 1) (k expr)
+
+  and apply_remaining_end params r =
+    match (r, params) with
+    | _, [] | None, _ -> r
+    | Some body, _ :: _ ->
+        Some (Exp.function_ (List.rev params) None (Pfunction_body body))
+
+  let find_label args lbl =
+    List.partition
+      (function
+        | (Labelled lbl' | Optional lbl'), _ -> lbl'.txt <> lbl | _ -> true)
+      args
+
+  let rec unapply args t =
+    match (args, t) with
+    | (Nolabel, arg) :: args_tl, Arg k -> unapply args_tl (k arg)
+    | _, End None -> None
+    | [], t -> apply_remaining_args [] 1 t
+    | args, Take_all k -> k args
+    | args, Label (lbl, k) -> (
+        match find_label args lbl with
+        | _, [] ->
+            Format.eprintf "Error: Label %S expected but not found" lbl;
+            None
+        | args_tl, (_, arg) :: _ -> unapply args_tl (k arg))
+    | args, Label_opt (lbl, k) -> (
+        match find_label args lbl with
+        | args_tl, (Labelled _, arg) :: _ ->
+            unapply args_tl (k (Some (arg, `Lbl)))
+        | args_tl, (Optional _, arg) :: _ ->
+            unapply args_tl (k (Some (arg, `Opt)))
+        | _ -> unapply args (k None))
+    | ((Labelled lbl | Optional lbl), _) :: _, Arg _ ->
+        Format.eprintf "Error: Unexpected label %S at %a\n%!" lbl.txt
+          Printast.fmt_location lbl.loc;
+        None
+    | (_, arg) :: _, End (Some _) ->
+        Format.eprintf "Error: Too many arguments at %a\n%!"
+          Printast.fmt_location arg.pexp_loc;
+        None
+
+  let take k = Arg k
+  let take_lbl lbl k = Label (lbl, k)
+  let take_lblopt lbl k = Label_opt (lbl, k)
+  let take_all k = Take_all k
+  let return r = End r
+end

--- a/lib/ocamlformat_utils/ocamlformat_utils.mli
+++ b/lib/ocamlformat_utils/ocamlformat_utils.mli
@@ -5,14 +5,19 @@ module Parsing : sig
   include module type of Ocamlformat_parser_extended
 end
 
+module Cmt = Ocamlformat_lib.Cmt
+
 module Ast_utils : module type of Ast_utils
 (** Utility functions for contructing AST nodes. *)
 
-open Parsing
+open Parsing.Parsetree
 
-val format_structure_in_place :
-  file:string ->
-  modify_ast:(Parsetree.structure -> Parsetree.structure) ->
-  (unit, [ `Msg of string ]) result
+type modify_ast = {
+  structure : structure -> structure * Cmt.t list;
+  signature : signature -> signature * Cmt.t list;
+}
+
+val format_in_place :
+  file:string -> modify_ast:modify_ast -> (unit, [ `Msg of string ]) result
 (** Format the content of and overwrite [file]. [modify_ast] can be used to
     apply any change to the program. Raises [Failure] and [Sys_error]. *)


### PR DESCRIPTION
These were initially added in https://github.com/Julow/lwt_ppx_to_let_syntax/pull/1. This reduces this other PR's diff while allowing the use of these libraries in parallel work.