### PR TITLE
dune-project: Correct dependencies

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -22,35 +22,16 @@
 (package
  (name lwt_ppx_to_let_syntax)
  (synopsis "A tool for migrating away from lwt_ppx")
- (depends ocaml cmdliner))
-
-(package
- (name lwt_to_direct_style)
- (synopsis
-  "A tool for migrating from Lwt to direct-style concurrency libraries")
  (depends
   ocaml
   cmdliner
-  (lwt :with-test)
-  (ocaml-index :with-test)))
-
-(package
- (name lwt_log_to_logs)
- (synopsis "A tool for migrating from Lwt_log to Logs.")
- (depends
-  ocaml
-  cmdliner
-  (lwt_log :with-test)
-  (js_of_ocaml-lwt :with-test)
-  (ocaml-index :with-test)))
-
-(package
- (name lwt_lint)
- (synopsis "A linter for code that might cause implicit forking in Lwt.")
- (depends
-  ocaml
-  cmdliner
-  base
+  ; OCamlformat depends
+  (ocaml
+   (>= 4.08))
+  (base
+   (>= v0.12.0))
+  (cmdliner
+   (>= 1.1.0))
   dune-build-info
   either
   fix
@@ -72,4 +53,122 @@
   (csexp
    (>= 1.4.0))
   astring
-  camlp-streams))
+  camlp-streams
+  re))
+
+(package
+ (name lwt_to_direct_style)
+ (synopsis
+  "A tool for migrating from Lwt to direct-style concurrency libraries")
+ (depends
+  ocaml
+  cmdliner
+  merlin-lib
+  (lwt :with-test)
+  (ocaml-index :with-test)
+  ; OCamlformat depends
+  (ocaml
+   (>= 4.08))
+  (base
+   (>= v0.12.0))
+  (cmdliner
+   (>= 1.1.0))
+  dune-build-info
+  either
+  fix
+  (fpath
+   (>= 0.7.3))
+  (menhir
+   (>= 20201216))
+  (menhirLib
+   (>= 20201216))
+  (menhirSdk
+   (>= 20201216))
+  (ocaml-version
+   (>= 3.5.0))
+  stdio
+  (uuseg
+   (>= 10.0.0))
+  (uutf
+   (>= 1.0.1))
+  (csexp
+   (>= 1.4.0))
+  astring
+  camlp-streams
+  re))
+
+(package
+ (name lwt_log_to_logs)
+ (synopsis "A tool for migrating from Lwt_log to Logs.")
+ (depends
+  ocaml
+  cmdliner
+  merlin-lib
+  (lwt_log :with-test)
+  (js_of_ocaml-lwt :with-test)
+  (ocaml-index :with-test)
+  ; OCamlformat depends
+  (ocaml
+   (>= 4.08))
+  (base
+   (>= v0.12.0))
+  (cmdliner
+   (>= 1.1.0))
+  dune-build-info
+  either
+  fix
+  (fpath
+   (>= 0.7.3))
+  (menhir
+   (>= 20201216))
+  (menhirLib
+   (>= 20201216))
+  (menhirSdk
+   (>= 20201216))
+  (ocaml-version
+   (>= 3.5.0))
+  stdio
+  (uuseg
+   (>= 10.0.0))
+  (uutf
+   (>= 1.0.1))
+  (csexp
+   (>= 1.4.0))
+  astring
+  camlp-streams
+  re))
+
+(package
+ (name lwt_lint)
+ (synopsis "A linter for code that might cause implicit forking in Lwt.")
+ (depends
+  ; OCamlformat depends
+  (ocaml
+   (>= 4.08))
+  (base
+   (>= v0.12.0))
+  (cmdliner
+   (>= 1.1.0))
+  dune-build-info
+  either
+  fix
+  (fpath
+   (>= 0.7.3))
+  (menhir
+   (>= 20201216))
+  (menhirLib
+   (>= 20201216))
+  (menhirSdk
+   (>= 20201216))
+  (ocaml-version
+   (>= 3.5.0))
+  stdio
+  (uuseg
+   (>= 10.0.0))
+  (uutf
+   (>= 1.0.1))
+  (csexp
+   (>= 1.4.0))
+  astring
+  camlp-streams
+  re))

--- a/lwt_lint.opam
+++ b/lwt_lint.opam
@@ -11,9 +11,9 @@ authors: [
 ]
 depends: [
   "dune" {>= "3.17"}
-  "ocaml"
-  "cmdliner"
-  "base"
+  "ocaml" {>= "4.08"}
+  "base" {>= "v0.12.0"}
+  "cmdliner" {>= "1.1.0"}
   "dune-build-info"
   "either"
   "fix"
@@ -28,6 +28,7 @@ depends: [
   "csexp" {>= "1.4.0"}
   "astring"
   "camlp-streams"
+  "re"
   "odoc" {with-doc}
 ]
 build: [

--- a/lwt_log_to_logs.opam
+++ b/lwt_log_to_logs.opam
@@ -16,6 +16,24 @@ depends: [
   "lwt_log" {with-test}
   "js_of_ocaml-lwt" {with-test}
   "ocaml-index" {with-test}
+  "ocaml" {>= "4.08"}
+  "base" {>= "v0.12.0"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "either"
+  "fix"
+  "fpath" {>= "0.7.3"}
+  "menhir" {>= "20201216"}
+  "menhirLib" {>= "20201216"}
+  "menhirSdk" {>= "20201216"}
+  "ocaml-version" {>= "3.5.0"}
+  "stdio"
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+  "csexp" {>= "1.4.0"}
+  "astring"
+  "camlp-streams"
+  "re"
   "odoc" {with-doc}
 ]
 build: [

--- a/lwt_ppx_to_let_syntax.opam
+++ b/lwt_ppx_to_let_syntax.opam
@@ -13,6 +13,24 @@ depends: [
   "dune" {>= "3.17"}
   "ocaml"
   "cmdliner"
+  "ocaml" {>= "4.08"}
+  "base" {>= "v0.12.0"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "either"
+  "fix"
+  "fpath" {>= "0.7.3"}
+  "menhir" {>= "20201216"}
+  "menhirLib" {>= "20201216"}
+  "menhirSdk" {>= "20201216"}
+  "ocaml-version" {>= "3.5.0"}
+  "stdio"
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+  "csexp" {>= "1.4.0"}
+  "astring"
+  "camlp-streams"
+  "re"
   "odoc" {with-doc}
 ]
 build: [

--- a/lwt_to_direct_style.opam
+++ b/lwt_to_direct_style.opam
@@ -14,8 +14,27 @@ depends: [
   "dune" {>= "3.17"}
   "ocaml"
   "cmdliner"
+  "merlin-lib"
   "lwt" {with-test}
   "ocaml-index" {with-test}
+  "ocaml" {>= "4.08"}
+  "base" {>= "v0.12.0"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "either"
+  "fix"
+  "fpath" {>= "0.7.3"}
+  "menhir" {>= "20201216"}
+  "menhirLib" {>= "20201216"}
+  "menhirSdk" {>= "20201216"}
+  "ocaml-version" {>= "3.5.0"}
+  "stdio"
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+  "csexp" {>= "1.4.0"}
+  "astring"
+  "camlp-streams"
+  "re"
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Notably, adds the dependencies for the vendored OCamlformat.