### PR TITLE
Fix missing `(fun () -> ..)` when translating `let* .. and*`

### DIFF
--- a/test/ciao_lwt/to_direct_style.t/run.t
+++ b/test/ciao_lwt/to_direct_style.t/run.t
@@ -400,17 +400,31 @@ Make a writable directory tree:
   
   let letops () =
     let (), `Ok =
-      Fiber.pair (Format.printf "3")
-        (let () = Format.printf "1" in
-         let () = Format.printf "2" in
-         `Ok)
+      Fiber.pair
+        (fun () -> Format.printf "3")
+        (fun () ->
+          let
+              (* TODO: ciao-lwt: This computation might not be suspended correctly. *)
+              () =
+            Format.printf "1"
+          in
+          let () = Format.printf "2" in
+          `Ok)
     in
     let (), ((), `Ok) =
-      Fiber.pair (Format.printf "6")
-        (Fiber.pair (Format.printf "7")
-           (let () = Format.printf "4" in
-            let () = Format.printf "5" in
-            `Ok))
+      Fiber.pair
+        (fun () -> Format.printf "6")
+        (fun () ->
+          Fiber.pair
+            (fun () -> Format.printf "7")
+            (fun () ->
+              let
+                  (* TODO: ciao-lwt: This computation might not be suspended correctly. *)
+                  () =
+                Format.printf "4"
+              in
+              let () = Format.printf "5" in
+              `Ok))
     in
     ()
   


### PR DESCRIPTION
This code:

    let* _ = f ()
    and* _ = g () in

was translated to:

    Fiber.pair (f ()) (g ())

which is not valid. The arguments to `Fiber.pair` are now suspended correctly.