### PR TITLE
Generate Promise.await for some let operators

### DIFF
--- a/bin/ciao_lwt/to_direct_style/ast_rewrite.ml
+++ b/bin/ciao_lwt/to_direct_style/ast_rewrite.ml
@@ -21,8 +21,16 @@ let mk_tuple_elem ?lbl exp = Lte_simple { lte_label = lbl; lte_elt = exp }
 (** Unlabelled tuple. *)
 let mk_pat_tuple elems = Pat.tuple (List.map mk_tuple_elem elems) Closed
 
+(** Rewrite the expression passed to [bind], [map], [let*], etc... If it's a
+    function application, it is turned into a direct call. Otherwise, it is
+    turned into an await. *)
+let rewrite_bind_exp ~backend exp =
+  match exp.pexp_desc with
+  | Pexp_apply _ -> exp
+  | _ -> backend#blocking_await exp
+
 (* Rewrite a continuation to a let binding, a match or an apply. *)
-let rewrite_continuation cont ~arg:cont_arg =
+let rewrite_continuation ~backend cont ~arg:cont_arg =
   let get =
     match cont.pexp_desc with
     | _ when cont.pexp_attributes <> [] -> `Apply
@@ -38,6 +46,7 @@ let rewrite_continuation cont ~arg:cont_arg =
         `Match cases
     | _ -> `Apply
   in
+  let cont_arg = rewrite_bind_exp ~backend cont_arg in
   match get with
   | `Let (arg_pat, body) -> mk_let arg_pat cont_arg body
   | `Match cases -> Exp.match_ cont_arg cases
@@ -198,11 +207,11 @@ let rewrite_apply_lwt ~backend ~state ident args =
   | "bind" ->
       take @@ fun promise_arg ->
       take @@ fun fun_arg ->
-      return (Some (rewrite_continuation fun_arg ~arg:promise_arg))
+      return (Some (rewrite_continuation ~backend fun_arg ~arg:promise_arg))
   | "map" ->
       take @@ fun fun_arg ->
       take @@ fun promise_arg ->
-      return (Some (rewrite_continuation fun_arg ~arg:promise_arg))
+      return (Some (rewrite_continuation ~backend fun_arg ~arg:promise_arg))
   | "try_bind" ->
       take @@ fun thunk ->
       take @@ fun value_f ->
@@ -284,10 +293,12 @@ let rewrite_apply_lwt ~backend ~state ident args =
   (* Operators *)
   | ">>=" | ">|=" ->
       take @@ fun lhs ->
-      take @@ fun rhs -> return (Some (rewrite_continuation rhs ~arg:lhs))
+      take @@ fun rhs ->
+      return (Some (rewrite_continuation ~backend rhs ~arg:lhs))
   | "=<<" | "=|<" ->
       take @@ fun lhs ->
-      take @@ fun rhs -> return (Some (rewrite_continuation lhs ~arg:rhs))
+      take @@ fun rhs ->
+      return (Some (rewrite_continuation ~backend lhs ~arg:rhs))
   | "<&>" ->
       take @@ fun lhs ->
       take @@ fun rhs ->
@@ -477,13 +488,6 @@ let can_simply_sequence ~state rhs =
       true
   | _ -> false
 
-(** Rewrite the expression after the [=]. If it's a function application, it is
-    turned into a direct call. Otherwise, it is turned into a await. *)
-let rewrite_letop_exp ~backend exp =
-  match exp.pexp_desc with
-  | Pexp_apply _ -> exp
-  | _ -> backend#blocking_await exp
-
 let rewrite_letop ~backend ~state let_ ands body = function
   | "Lwt", ("let*" | "let+") -> (
       match ands with
@@ -491,7 +495,7 @@ let rewrite_letop ~backend ~state let_ ands body = function
           Some
             (mk_let ~is_pun:let_.pbop_is_pun ?value_constraint:let_.pbop_typ
                let_.pbop_pat ~args:let_.pbop_args
-               (rewrite_letop_exp ~backend let_.pbop_exp)
+               (rewrite_bind_exp ~backend let_.pbop_exp)
                body)
       | _ :: _ ->
           List.iter (fun and_ -> Occ.remove_s state and_.pbop_op) ands;

--- a/bin/ciao_lwt/to_direct_style/ast_rewrite.ml
+++ b/bin/ciao_lwt/to_direct_style/ast_rewrite.ml
@@ -477,13 +477,22 @@ let can_simply_sequence ~state rhs =
       true
   | _ -> false
 
+(** Rewrite the expression after the [=]. If it's a function application, it is
+    turned into a direct call. Otherwise, it is turned into a await. *)
+let rewrite_letop_exp ~backend exp =
+  match exp.pexp_desc with
+  | Pexp_apply _ -> exp
+  | _ -> backend#blocking_await exp
+
 let rewrite_letop ~backend ~state let_ ands body = function
   | "Lwt", ("let*" | "let+") -> (
       match ands with
       | [] ->
           Some
             (mk_let ~is_pun:let_.pbop_is_pun ?value_constraint:let_.pbop_typ
-               let_.pbop_pat ~args:let_.pbop_args let_.pbop_exp body)
+               let_.pbop_pat ~args:let_.pbop_args
+               (rewrite_letop_exp ~backend let_.pbop_exp)
+               body)
       | _ :: _ ->
           List.iter (fun and_ -> Occ.remove_s state and_.pbop_op) ands;
           let let_pat, let_exp = split_binding_op ~state let_

--- a/bin/ciao_lwt/to_direct_style/concurrency_backend.ml
+++ b/bin/ciao_lwt/to_direct_style/concurrency_backend.ml
@@ -116,6 +116,7 @@ let eio ~eio_sw_as_fiber_var ~eio_env_as_fiber_var add_comment =
          promise when it's part of control-flow.";
       mk_apply_simple (promise_ident "create") [ unit ]
 
+    method blocking_await exp = mk_apply_simple (promise_ident "await") [ exp ]
     method wakeup u arg = mk_apply_simple (promise_ident "resolve") [ u; arg ]
     method join lst = mk_apply_simple (fiber_ident "all") [ lst ]
     method pause unit = mk_apply_simple (fiber_ident "yield") [ unit ]

--- a/test/ciao_lwt/to_direct_style.t/run.t
+++ b/test/ciao_lwt/to_direct_style.t/run.t
@@ -51,7 +51,7 @@ Make a writable directory tree:
     Lwt.return_unit (line 49 column 3)
     Lwt.return (line 53 column 3)
     Lwt.return (line 57 column 3)
-  lib/test.ml: (187 occurrences)
+  lib/test.ml: (190 occurrences)
     Lwt.Infix (line 1 column 6)
     Lwt.Syntax (line 2 column 6)
     Lwt.try_bind (line 5 column 3)
@@ -239,6 +239,9 @@ Make a writable directory tree:
     Lwt.catch (line 200 column 9)
     Lwt.return_unit (line 200 column 30)
     Lwt.reraise (line 200 column 47)
+    Lwt.let* (line 203 column 3)
+    Lwt.return (line 204 column 3)
+    Lwt.let+ (line 207 column 3)
   lib/test_lwt_unix.ml: (57 occurrences)
     Lwt.Syntax (line 1 column 6)
     Lwt_unix.of_unix_file_descr (line 6 column 8)
@@ -702,6 +705,14 @@ Make a writable directory tree:
   let _ = (fun () -> ()) ()
   let _f x = Fiber.yield (match x with Some _ -> () | _ -> ())
   let _ = ()
+  
+  let _ =
+    let x = Promise.await x in
+    x
+  
+  let _ =
+    let x = Promise.await x in
+    x
 
   $ cat lib/test.mli
   open Eio.Std

--- a/test/ciao_lwt/to_direct_style.t/run.t
+++ b/test/ciao_lwt/to_direct_style.t/run.t
@@ -338,6 +338,8 @@ Make a writable directory tree:
     Lwt_mutex.t (line 3 column 10)
 
   $ cat bin/main.ml
+  open Eio.Std
+  
   let _main () =
     match
       let () = Format.printf "Main.main" in
@@ -375,7 +377,7 @@ Make a writable directory tree:
     | v -> v
     | exception Eio.Time.Timeout -> 0
   
-  let _ = match x with 0 -> true | _ -> false
+  let _ = match Promise.await x with 0 -> true | _ -> false
   let _ = print_endline "Hello"
   let _ = print_endline "Hello"
   
@@ -458,8 +460,8 @@ Make a writable directory tree:
   
   let lwt_calls_rebind () =
     let tr = fun x1 x2 x3 -> match x1 () with v -> x2 v | exception v -> x3 v in
-    let b = fun x1 x2 -> x2 x1 in
-    let ( >> ) = fun x1 x2 -> x2 x1 in
+    let b = fun x1 x2 -> x2 (Promise.await x1) in
+    let ( >> ) = fun x1 x2 -> x2 (Promise.await x1) in
     let p fmt = Format.printf fmt in
     let ( ~@ ) = fun x1 -> x1 in
     tr
@@ -497,14 +499,15 @@ Make a writable directory tree:
     Format.printf "Test.test";
     let _ = Fiber.pair lwt_calls lwt_calls_point_free in
     let _ =
-      let a = lwt_calls () and b = lwt_calls_point_free () in
-      Fiber.pair
-        (fun () ->
-          a
-          (* TODO: ciao-lwt: This computation might not be suspended correctly. *))
-        (fun () ->
-          b
-          (* TODO: ciao-lwt: This computation might not be suspended correctly. *))
+      Promise.await
+        (let a = lwt_calls () and b = lwt_calls_point_free () in
+         Fiber.pair
+           (fun () ->
+             a
+             (* TODO: ciao-lwt: This computation might not be suspended correctly. *))
+           (fun () ->
+             b
+             (* TODO: ciao-lwt: This computation might not be suspended correctly. *)))
     in
     Fiber.all
       [
@@ -551,8 +554,8 @@ Make a writable directory tree:
   
   let _ = raise Not_found
   let _ = failwith "not found"
-  let _ = x
-  let _ = Fun.id x
+  let _ = Promise.await x
+  let _ = Fun.id (Promise.await x)
   
   let _ =
     Fiber.any
@@ -679,7 +682,7 @@ Make a writable directory tree:
   
   let i : (unit Promise.t -> unit) -> unit = fun f -> f x
   let _ = ()
-  let _ = fun x1 x2 -> x2 x1
+  let _ = fun x1 x2 -> x2 (Promise.await x1)
   let _ = ( let* )
   
   let _ =
@@ -703,7 +706,7 @@ Make a writable directory tree:
     f ()
   
   let _ = (fun () -> ()) ()
-  let _f x = Fiber.yield (match x with Some _ -> () | _ -> ())
+  let _f x = Fiber.yield (Promise.await (match x with Some _ -> () | _ -> ()))
   let _ = ()
   
   let _ =

--- a/test/ciao_lwt/to_direct_style.t/src/lib/test.ml
+++ b/test/ciao_lwt/to_direct_style.t/src/lib/test.ml
@@ -198,3 +198,11 @@ let _f x =
   >>= Lwt.pause
 
 let _ = Lwt.catch (fun () -> Lwt.return_unit) Lwt.reraise
+
+let _ =
+  let* x = x in
+  Lwt.return x
+
+let _ =
+  let+ x = x in
+  x


### PR DESCRIPTION
Let bindings where the bound expression is not a function application are turned into `Promise.await`.

This helps detect implicit forks like:

    let x = asynchronous_code () in
    let* x = x in
    ..

which were previously rewritten to:

    let x = asynchronous_code () in
    let x = x in
    ..

The problem was that `asynchronous_code ()` was no longer asynchronous and would block the execution at a different location than before. This is now turned to:

    let x = asynchronous_code () in
    let x = Promise.await x in
    ..

The problem is still here but the compiler now generates an error. The user can fix the error by either changing `asynchronous_code` to return a promise to emulate the previous behavior of drop the call to `Promise.await` if the order of execution is still correct.